### PR TITLE
Allow filter as a valid parameter for GET requests

### DIFF
--- a/synapsepy/http_client.py
+++ b/synapsepy/http_client.py
@@ -65,7 +65,6 @@ class HttpClient():
 			'issue_public_key',
 			'show_refresh_tokens',
 			'subnet_id',
-			'type',
 			'foreign_transaction',
 			'full_dehydrate',
 			'force_refresh',
@@ -76,7 +75,8 @@ class HttpClient():
 			'scope',
 			'lat',
 			'lon',
-			'zip'
+			'zip',
+			'filter'
 		]
 
 		parameters = {}


### PR DESCRIPTION
The Synapse API seems to allow adding `filter` as a HTTP GET Parameter to filter entities on a given path, but the feature is not available in the current Python SDK as `"filter"` is not in the list of accepted param keys.
Allowing to user filter will enable calls such as 
```py
user.get_all_node_trans(node_id, filter={"to.meta.type":"ACH"})
```
to retrieve all the ACH transactions of a node.

I also removed an instance of `"type"` as it already was in the list